### PR TITLE
tweak rstudio's use of vc features and runtimes

### DIFF
--- a/rstudio-feedstock/recipe/meta.yaml
+++ b/rstudio-feedstock/recipe/meta.yaml
@@ -56,9 +56,7 @@ source:
 
 build:
   number: 2
-  skip: True           # [win and py!=36]
-  features:
-    - vc{{ vc }}       # [win]
+  skip: True           # [win and vc!=14]
 
 requirements:
   build:
@@ -112,7 +110,6 @@ requirements:
     - m2-openssh                        # [win]
     # TODO :: Add this
     # - m2-winpty                         # [win]
-    - vs2015_runtime                    # [win]
     - pandoc >=1.19.2                   # [not linux]
     - pandoc >=1.15.0                   # [linux]
     - fonts-anaconda


### PR DESCRIPTION
removed vs2015_runtime because the run_exports of ``vc 14.*`` from {{compiler('cxx')}} will bring it in.

the other stuff changes this to tie the build more strictly to a particular vc version, rather than a python version.  Same effect, just stated more clearly.

The feature here wasn't actually doing anything for us.  Getting rid of it and depending on the vc package dep to handle the feature is more correct.