### PR TITLE
Update r-leidenalg, rebuild r-protolite on linux-64

### DIFF
--- a/r-leidenalg-feedstock/recipe/meta.yaml
+++ b/r-leidenalg-feedstock/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '1.1.2' %}
+{% set version = '1.1.3' %}
 
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
@@ -11,7 +11,7 @@ source:
   url:
     - {{ cran_mirror }}/src/contrib/leidenAlg_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/leidenAlg/leidenAlg_{{ version }}.tar.gz
-  sha256: 9f06af4c623438099b5fd8a69d475275fdf71ecf75eb859053ef22e132f00a73
+  sha256: 3db4840c34ee9218a30e4ca6096239eb7da2b0c94ef3f3d449968f9fb3d18f3c
 
 build:
   merge_build_host: True  # [win]
@@ -95,7 +95,7 @@ about:
 # Package: leidenAlg
 # Type: Package
 # Title: Implements the Leiden Algorithm via an R Interface
-# Version: 1.1.2
+# Version: 1.1.3
 # Authors@R: c(person("Peter", "Kharchenko", email = "Peter_Kharchenko@hms.harvard.edu", role = c("aut")), person("Viktor", "Petukhov", email = "viktor.s.petukhov@ya.ru", role = c("aut")), person("Yichen", "Wang", email = "wayichen@umich.edu", role=c("aut")), person("V.A.", "Traag", email = "v.a.traag@cwts.leidenuniv.nl", role = c("ctb")), person("Gabor", "Csardi", email = "sardi.gabor@gmail.com", role = c("ctb")), person("Tamas", "Nepusz", email = "ntamas@gmail.com", role = c("ctb")), person("Minh Van", "Nguyen", email = "nguyenminh2@gmail.com", role = c("ctb")), person("Evan", "Biederstedt", email = "evan.biederstedt@gmail.com", role=c("cre", "aut")))
 # Description: An R interface to the Leiden algorithm, an iterative community detection algorithm on networks. The algorithm is designed to converge to a partition in which all subsets of all communities are locally optimally assigned, yielding communities guaranteed to be connected. The implementation proves to be fast, scales well, and can be run on graphs of millions of nodes (as long as they can fit in memory). The original implementation was constructed as a python interface "leidenalg" found here: <https://github.com/vtraag/leidenalg>. The algorithm was originally described in Traag, V.A., Waltman, L. & van Eck, N.J. "From Louvain to Leiden: guaranteeing well-connected communities". Sci Rep 9, 5233 (2019) <doi:10.1038/s41598-019-41695-z>.
 # License: GPL-3
@@ -113,9 +113,9 @@ about:
 # NeedsCompilation: yes
 # Author: Peter Kharchenko [aut], Viktor Petukhov [aut], Yichen Wang [aut], V.A. Traag [ctb], Gabor Csardi [ctb], Tamas Nepusz [ctb], Minh Van Nguyen [ctb], Evan Biederstedt [cre, aut]
 # Maintainer: Evan Biederstedt <evan.biederstedt@gmail.com>
-# Packaged: 2023-09-05 20:56:22 UTC; evanbiederstedt
+# Packaged: 2024-02-27 22:15:21 UTC; evanbiederstedt
 # Repository: CRAN
-# Date/Publication: 2023-09-06 07:00:02 UTC
+# Date/Publication: 2024-02-27 22:50:02 UTC
 
 # See
 # https://docs.conda.io/projects/conda-build for

--- a/r-protolite-feedstock/recipe/meta.yaml
+++ b/r-protolite-feedstock/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   merge_build_host: True  # [win]
   # If this is a new build for the same version, increment the build number.
-  number: 0
+  number: 1
   # no skip
 
   # This is required to make R link correctly on Linux.


### PR DESCRIPTION
**Destination channel:** **r**

### Links

- [PKG-5050](https://anaconda.atlassian.net/browse/PKG-5050) 
- https://cran.r-project.org/web/packages/leidenAlg/index.html
- https://cran.r-project.org/web/packages/protolite/index.html

### Explanation of changes:

- Update the recipe by `conda skeleton`

### Notes:

- Updating `r-leidenalg` to `1.1.3` against `libxml2 2.13` on **linux-64** only
- Rebuilding `r-protolite 2.3.0` against `protobuf` on **linux-64** only

[PKG-5050]: https://anaconda.atlassian.net/browse/PKG-5050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ