### PR TITLE
r-archive 1.1.9

### DIFF
--- a/r-archive-feedstock/recipe/meta.yaml
+++ b/r-archive-feedstock/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '1.1.6' %}
+{% set version = '1.1.9' %}
 
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
@@ -11,7 +11,7 @@ source:
   url:
     - {{ cran_mirror }}/src/contrib/archive_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/archive/archive_{{ version }}.tar.gz
-  sha256: ece03367ad10e35b3c4d4a7fa9b01e5a0e68604c43461f11d6e9ef25fecc504b
+  sha256: 7d4e9acf18f79377331f4c4f976a4762b0f7f92592773aadd29f295d506b9e8c
 
 build:
   merge_build_host: True  # [win]
@@ -45,7 +45,6 @@ requirements:
   host:
     - r-base
     - r-cli
-    - r-cpp11
     - r-glue
     - r-rlang
     - r-tibble
@@ -55,7 +54,6 @@ requirements:
     - r-base
     - {{native}}gcc-libs         # [win]
     - r-cli
-    - r-cpp11
     - r-glue
     - r-rlang
     - r-tibble
@@ -89,7 +87,7 @@ about:
 
 # Package: archive
 # Title: Multi-Format Archive and Compression Support
-# Version: 1.1.6
+# Version: 1.1.9
 # Authors@R: c( person("Jim", "Hester", role = "aut", comment = c(ORCID = "0000-0002-2739-7082")), person("Gabor", "Csardi", , "csardi.gabor@gmail.com", role = c("aut", "cre")), person("Ondrej", "Holy", role = "cph", comment = "archive_write_add_filter implementation"), person("RStudio", role = c("cph", "fnd")) )
 # Description: Bindings to 'libarchive' <http://www.libarchive.org> the Multi-format archive and compression library. Offers R connections and direct extraction for many archive formats including 'tar', 'ZIP', '7-zip', 'RAR', 'CAB' and compression formats including 'gzip', 'bzip2', 'compress', 'lzma' and 'xz'.
 # License: MIT + file LICENSE
@@ -98,18 +96,18 @@ about:
 # Depends: R (>= 3.6.0)
 # Imports: cli, glue, rlang, tibble
 # Suggests: covr, testthat
-# LinkingTo: cli, cpp11
+# LinkingTo: cli
 # ByteCompile: true
 # Encoding: UTF-8
-# RoxygenNote: 7.2.3
+# RoxygenNote: 7.3.1
 # SystemRequirements: libarchive: libarchive-dev (deb), libarchive-devel (rpm), libarchive (homebrew), libarchive_dev (csw)
 # Biarch: true
 # NeedsCompilation: yes
-# Packaged: 2023-09-17 10:54:08 UTC; gaborcsardi
+# Packaged: 2024-09-12 10:40:59 UTC; gaborcsardi
 # Author: Jim Hester [aut] (<https://orcid.org/0000-0002-2739-7082>), Gabor Csardi [aut, cre], Ondrej Holy [cph] (archive_write_add_filter implementation), RStudio [cph, fnd]
 # Maintainer: Gabor Csardi <csardi.gabor@gmail.com>
 # Repository: CRAN
-# Date/Publication: 2023-09-18 08:30:02 UTC
+# Date/Publication: 2024-09-12 17:40:50 UTC
 
 # See
 # https://docs.conda.io/projects/conda-build for


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5521](https://anaconda.atlassian.net/browse/PKG-5521) 
- [Upstream repository](https://github.com/r-lib/archive/tree/v1.1.9)

### Explanation of changes:

- Update the recipe by the conda skeleton command:
`conda skeleton cran --cran-url https://cran.r-project.org --output-suffix=-feedstock/recipe --recursive --update-policy=merge-keep-build-num --r-interp=r-base --use-noarch-generic r-archive`

### Notes:

- Updating with libarchive 3.7.4  because `libarchive <3.7.4` is affected by CVE-2024-37407 with a score of 9.1.
- It's a manual build on a dev machine for `linux-64` only

[PKG-5521]: https://anaconda.atlassian.net/browse/PKG-5521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ