### PR TITLE
Rebuild r-pdftools for poppler v24.09.0

### DIFF
--- a/r-pdftools-feedstock/recipe/meta.yaml
+++ b/r-pdftools-feedstock/recipe/meta.yaml
@@ -16,8 +16,9 @@ source:
 build:
   merge_build_host: True  # [win]
   # If this is a new build for the same version, increment the build number.
-  number: 0
-  # no skip
+  number: 1
+  # Poppler >=24.09.0 requires Qt which does not exist on s390x.
+  skip: True  # [s390x]
 
   # This is required to make R link correctly on Linux.
   rpaths:
@@ -46,14 +47,14 @@ requirements:
     - r-base
     - r-rcpp >=0.12.12
     - r-qpdf
-    - poppler
+    - poppler 24.09.0
 
   run:
     - r-base
     - {{native}}gcc-libs         # [win]
     - r-rcpp >=0.12.12
     - r-qpdf
-    - poppler
+    - {{ pin_compatible('poppler', max_pin='x.x.x') }}
 
 test:
   commands:


### PR DESCRIPTION
r-pdftools 3.4.0

**Destination channel:** defaults

### Links

- [PKG-6112](https://anaconda.atlassian.net/browse/PKG-6112)
- [Upstream repository](https://github.com/ropensci/pdftools/tree/master)

### Explanation of changes:

- Update poppler pinnings for latest version


[PKG-6112]: https://anaconda.atlassian.net/browse/PKG-6112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ