### PR TITLE
Rebuild r-rpostgresql against postgresql v17.0

### DIFF
--- a/r-rpostgresql-feedstock/recipe/meta.yaml
+++ b/r-rpostgresql-feedstock/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   merge_build_host: True  # [win]
   # If this is a new build for the same version, increment the build number.
-  number: 0
+  number: 1
   # no skip
 
   # This is required to make R link correctly on Linux.
@@ -42,13 +42,13 @@ requirements:
   host:
     - r-base
     - r-dbi >=0.3
-    - postgresql
+    - postgresql 17.0
 
   run:
     - r-base
     - {{native}}gcc-libs         # [win]
     - r-dbi >=0.3
-    - postgresql
+    - {{ pin_compatible('postgresql', max_pin='x.x.x') }}
 
 test:
   commands:

--- a/r-rpostgresql-feedstock/recipe/meta.yaml
+++ b/r-rpostgresql-feedstock/recipe/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - r-base
     - {{native}}gcc-libs         # [win]
     - r-dbi >=0.3
-    - {{ pin_compatible('postgresql', max_pin='x.x.x') }}
+    - postgresql
 
 test:
   commands:


### PR DESCRIPTION
r-rpostgres 0.7-5 b1

**Destination channel:** defaults

### Links

- [PKG-6157](https://anaconda.atlassian.net/browse/PKG-6157)
- [Upstream repository](https://github.com/tomoakin/RPostgreSQL)
- Relevant dependency PRs:
  - AnacondaRecipes/postgresql-feedstock#10



[PKG-6157]: https://anaconda.atlassian.net/browse/PKG-6157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ