### PR TITLE
Rebuild r-lwgeom against postgresql v17.0

### DIFF
--- a/r-lwgeom-feedstock/recipe/meta.yaml
+++ b/r-lwgeom-feedstock/recipe/meta.yaml
@@ -64,7 +64,7 @@ requirements:
     - geos
     - proj
     - sqlite
-    - {{ pin_compatible('postgresql', max_pin='x.x.x') }}
+    - postgresql
 test:
   commands:
     # You can put additional test commands to be run here.

--- a/r-lwgeom-feedstock/recipe/meta.yaml
+++ b/r-lwgeom-feedstock/recipe/meta.yaml
@@ -49,7 +49,7 @@ requirements:
   host:
     - r-base
     - r-rcpp
-    - r-sf >=0.9_3
+    - r-sf >=1.0_14
     - r-units
     - geos
     - proj
@@ -59,7 +59,7 @@ requirements:
     - r-base
     - {{native}}gcc-libs         # [win]
     - r-rcpp
-    - r-sf >=0.9_3
+    - r-sf >=1.0_14
     - r-units
     - geos
     - proj

--- a/r-lwgeom-feedstock/recipe/meta.yaml
+++ b/r-lwgeom-feedstock/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   merge_build_host: True  # [win]
   # If this is a new build for the same version, increment the build number.
-  number: 0
+  number: 1
   # no skip
 
   # This is required to make R link correctly on Linux.
@@ -44,7 +44,7 @@ requirements:
     - proj
     - geos
     - sqlite
-    - postgresql
+    - postgresql 17.0
 
   host:
     - r-base
@@ -54,7 +54,7 @@ requirements:
     - geos
     - proj
     - sqlite
-    - postgresql
+    - postgresql 17.0
   run:
     - r-base
     - {{native}}gcc-libs         # [win]
@@ -64,7 +64,7 @@ requirements:
     - geos
     - proj
     - sqlite
-    - postgresql
+    - {{ pin_compatible('postgresql', max_pin='x.x.x') }}
 test:
   commands:
     # You can put additional test commands to be run here.


### PR DESCRIPTION
r-lwgeom 0.2-13 b1

**Destination channel:** defaults

### Links

- [PKG-6159](https://anaconda.atlassian.net/browse/PKG-6159)
- [Upstream repository](https://github.com/r-spatial/lwgeom/)
- Relevant dependency PRs:
  - AnacondaRecipes/postgresql-feedstock#10
  - AnacondaRecipes/r-sf-feedstock#2



[PKG-6159]: https://anaconda.atlassian.net/browse/PKG-6159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ