### PR TITLE
Rebuild r-rpostgres against postgresql v17.0

### DIFF
--- a/r-rpostgres-feedstock/recipe/meta.yaml
+++ b/r-rpostgres-feedstock/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   merge_build_host: True  # [win]
   # If this is a new build for the same version, increment the build number.
-  number: 0
+  number: 1
   # no skip
 
   # This is required to make R link correctly on Linux.

--- a/r-rpostgres-feedstock/recipe/meta.yaml
+++ b/r-rpostgres-feedstock/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - r-lubridate
     - r-plogr >=0.2.0
     - r-withr
-    - postgresql
+    - postgresql 17.0
 
   run:
     - r-base
@@ -65,7 +65,7 @@ requirements:
     - r-lubridate
     - r-plogr >=0.2.0
     - r-withr
-    - postgresql
+    - {{ pin_compatible('postgresql', max_pin='x.x.x') }}
 
 test:
   commands:

--- a/r-rpostgres-feedstock/recipe/meta.yaml
+++ b/r-rpostgres-feedstock/recipe/meta.yaml
@@ -65,7 +65,7 @@ requirements:
     - r-lubridate
     - r-plogr >=0.2.0
     - r-withr
-    - {{ pin_compatible('postgresql', max_pin='x.x.x') }}
+    - postgresql
 
 test:
   commands:


### PR DESCRIPTION
r-rpostgres 1.4.5 b1

**Destination channel:** defaults

### Links

- [PKG-6158](https://anaconda.atlassian.net/browse/PKG-6158)
- [Upstream repository](https://github.com/r-dbi/RPostgres)
- Relevant dependency PRs:
  - AnacondaRecipes/postgresql-feedstock#10



[PKG-6158]: https://anaconda.atlassian.net/browse/PKG-6158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ