### PR TITLE
Rebuild feedstocks with geos 3.10.6

### DIFF
--- a/r-apcf-feedstock/recipe/meta.yaml
+++ b/r-apcf-feedstock/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   merge_build_host: True  # [win]
   # If this is a new build for the same version, increment the build number.
-  number: 0
+  number: 1
   # no skip
 
   # This is required to make R link correctly on Linux.

--- a/r-exactextractr-feedstock/recipe/meta.yaml
+++ b/r-exactextractr-feedstock/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   merge_build_host: True  # [win]
   # If this is a new build for the same version, increment the build number.
-  number: 0
+  number: 1
   # no skip
 
   # This is required to make R link correctly on Linux.

--- a/r-lwgeom-feedstock/recipe/meta.yaml
+++ b/r-lwgeom-feedstock/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   merge_build_host: True  # [win]
   # If this is a new build for the same version, increment the build number.
-  number: 1
+  number: 2
   # no skip
 
   # This is required to make R link correctly on Linux.

--- a/r-terra-feedstock/recipe/meta.yaml
+++ b/r-terra-feedstock/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '1.7-55' %}
+{% set version = '1.8-5' %}
 
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
@@ -11,7 +11,7 @@ source:
   url:
     - {{ cran_mirror }}/src/contrib/terra_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/terra/terra_{{ version }}.tar.gz
-  sha256: 7000bdfd8591be64921cf841ef29b2aad74661781865f29e1540e57a7d7231ec
+  sha256: b05e0fe5e4ec7916b85673498191db48c8ed762cae035bb52dc941f79c8d5f2e
 
 build:
   merge_build_host: True  # [win]
@@ -24,7 +24,7 @@ build:
     - lib/R/lib/
     - lib/
 
-# Suggests: parallel, tinytest, ncdf4, sf (>= 0.9-8), deldir, XML, leaflet, htmlwidgets
+# Suggests: parallel, tinytest, ncdf4, sf (>= 0.9-8), deldir, XML, leaflet (>= 2.2.1), htmlwidgets
 requirements:
   build:
     - {{ compiler('c') }}              # [not win]
@@ -42,7 +42,6 @@ requirements:
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
     - libgdal
-
   host:
     - r-base
     - r-rcpp >=1.0_10
@@ -64,14 +63,14 @@ test:
     - $R -e "library('terra')"           # [not win]
     - "\"%R%\" -e \"library('terra')\""  # [win]
 
-  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
-  # in the recipe that will be run at test time.
+  # You can also put a file called run_test.r, run_test.py, run_test.sh,
+  # or run_test.bat in the recipe that will be run at test time.
 
   # requires:
     # Put any additional test requirements here.
 
 about:
-  home: https://rspatial.org/
+  home: https://rspatial.org/, https://rspatial.github.io/terra/
   license: GPL-3
   summary: Methods for spatial data analysis with vector (points, lines, polygons) and raster
     (grid) data. Methods for vector data include geometric operations such as intersect
@@ -90,10 +89,10 @@ about:
 # Package: terra
 # Type: Package
 # Title: Spatial Data Analysis
-# Version: 1.7-55
-# Date: 2023-10-13
+# Version: 1.8-5
+# Date: 2024-12-11
 # Depends: R (>= 3.5.0)
-# Suggests: parallel, tinytest, ncdf4, sf (>= 0.9-8), deldir, XML, leaflet, htmlwidgets
+# Suggests: parallel, tinytest, ncdf4, sf (>= 0.9-8), deldir, XML, leaflet (>= 2.2.1), htmlwidgets
 # LinkingTo: Rcpp
 # Imports: methods, Rcpp (>= 1.0-10)
 # SystemRequirements: C++17, GDAL (>= 2.2.3), GEOS (>= 3.4.0), PROJ (>= 4.9.3), sqlite3
@@ -102,15 +101,15 @@ about:
 # Maintainer: Robert J. Hijmans <r.hijmans@gmail.com>
 # Description: Methods for spatial data analysis with vector (points, lines, polygons) and raster (grid) data. Methods for vector data include geometric operations such as intersect and buffer. Raster methods include local, focal, global, zonal and geometric operations. The predict and interpolate methods facilitate the use of regression type (interpolation, machine learning) models for spatial prediction, including with satellite remote sensing data. Processing of very large files is supported. See the manual and tutorials on <https://rspatial.org/> to get started. 'terra' replaces the 'raster' package ('terra' can do more, and it is faster and easier to use).
 # License: GPL (>= 3)
-# URL: https://rspatial.org/
+# URL: https://rspatial.org/, https://rspatial.github.io/terra/
 # BugReports: https://github.com/rspatial/terra/issues/
 # LazyLoad: yes
-# Authors@R: c( person("Robert J.", "Hijmans", role = c("cre", "aut"), email = "r.hijmans@gmail.com", comment = c(ORCID = "0000-0001-5872-2872")), person("Roger", "Bivand",  role = "ctb", comment = c(ORCID = "0000-0003-2392-6140")), person("Edzer", "Pebesma", role = "ctb", comment = c(ORCID = "0000-0001-8049-7069")), person("Michael D.", "Sumner", role = "ctb"))
+# Authors@R: c( person("Robert J.", "Hijmans", role = c("cre", "aut"), email = "r.hijmans@gmail.com", comment = c(ORCID = "0000-0001-5872-2872")), person("Roger", "Bivand",  role = "ctb", comment = c(ORCID = "0000-0003-2392-6140")), person("Emanuele", "Cordano", role="ctb",comment = c(ORCID=  "0000-0002-3508-5898")), person("Krzysztof", "Dyba",  role = "ctb", comment = c(ORCID = "0000-0002-8614-3816")), person("Edzer", "Pebesma", role = "ctb", comment = c(ORCID = "0000-0001-8049-7069")), person("Michael D.", "Sumner", role = "ctb"))
 # NeedsCompilation: yes
-# Packaged: 2023-10-13 09:04:31 UTC; rhijm
-# Author: Robert J. Hijmans [cre, aut] (<https://orcid.org/0000-0001-5872-2872>), Roger Bivand [ctb] (<https://orcid.org/0000-0003-2392-6140>), Edzer Pebesma [ctb] (<https://orcid.org/0000-0001-8049-7069>), Michael D. Sumner [ctb]
+# Packaged: 2024-12-11 16:36:44 UTC; rhijm
+# Author: Robert J. Hijmans [cre, aut] (<https://orcid.org/0000-0001-5872-2872>), Roger Bivand [ctb] (<https://orcid.org/0000-0003-2392-6140>), Emanuele Cordano [ctb] (<https://orcid.org/0000-0002-3508-5898>), Krzysztof Dyba [ctb] (<https://orcid.org/0000-0002-8614-3816>), Edzer Pebesma [ctb] (<https://orcid.org/0000-0001-8049-7069>), Michael D. Sumner [ctb]
 # Repository: CRAN
-# Date/Publication: 2023-10-13 12:50:02 UTC
+# Date/Publication: 2024-12-12 10:00:02 UTC
 
 # See
 # https://docs.conda.io/projects/conda-build for


### PR DESCRIPTION
Rebuild `geos`'s downstream **R** packages r-terra, r-lwgeom, r-exactextractr, r-apcf:
- Update `r-terra` to `1.8-5`
- Rebuild `r-lwgeom`, and bump the build number to `2`.
- Rebuild `r-exactextractr`, and bump the build number to `1`. It depends on `r-sf`.
- Rebuild `r-apcf`, and bump the build number to `1`.

See https://metayaml-conda.fly.dev/metayaml/reverse_dependencies?name=geos

All these packages have been built for `linux-64` on the dev machine and uploaded to the testing channel https://anaconda.org/skupr/repo.

### Notes:
- I'm rebuilding `r-sf` separately because its feedstock resides in `AnacondaRecipes` org and the `aggregate` repo - https://github.com/AnacondaRecipes/r-sf-feedstock/pull/3
- `r-rgeos` was removed from the CRAN repository so we don't rebuild it.


