### PR TITLE
r-hdf5r 1.3.12; update cbc.yaml

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,25 +1,27 @@
 cran_mirror:
   - https://cran.r-project.org
 CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.10.sdk        # [osx and x86_64]
+  - /opt/MacOSX10.15.sdk        # [osx and x86_64]
   - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [osx and arm64]
 VERBOSE_AT:
   - V=1
 VERBOSE_CM:
   - VERBOSE=1
 macos_min_version:
-  - 10.9
+  - 10.15  # [osx and x86_64]
+  - 11.1   # [osx and arm64]
 macos_machine:
   - x86_64-apple-darwin13.4.0  # [osx and x86_64]
   - arm64-apple-darwin20.0.0   # [osx and arm64]
 MACOSX_DEPLOYMENT_TARGET:
-  - 10.9  # [osx and x86_64]
+  - 10.15 # [osx and x86_64]
   - 11.1  # [osx and arm64]
 python:
-  - 3.8
   - 3.9
   - "3.10"
   - "3.11"
+  - "3.12"
+  - "3.13"  # [ANACONDA_ROCKET_ENABLE_PY313]
 openblas:
   - 0.3.21
 cairo:
@@ -27,11 +29,11 @@ cairo:
 c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
-  - vs2017                     # [win]
+  - vs2019                     # [win]
 cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
-  - vs2017                     # [win]
+  - vs2019                     # [win]
 c_compiler_version:            # [linux or osx]
   - 11.2.0                     # [linux]
   - 14                         # [osx]
@@ -50,6 +52,12 @@ m2w64_cxx_compiler:            # [win]
   - m2w64-toolchain            # [win]
 m2w64_fortran_compiler:        # [win]
   - m2w64-toolchain            # [win]
+ucrt64_c_compiler:             # [win]
+  - ucrt64-gcc-toolchain       # [win]
+ucrt64_cxx_compiler:           # [win]
+  - ucrt64-gcc-toolchain       # [win]
+ucrt64_fortran_compiler:       # [win]
+  - ucrt64-gcc-toolchain       # [win]
 
 
 # This differs from target_platform in that it determines what subdir the compiler

--- a/r-hdf5r-feedstock/recipe/meta.yaml
+++ b/r-hdf5r-feedstock/recipe/meta.yaml
@@ -52,8 +52,6 @@ requirements:
     - r-r6
     - r-bit64
     - hdf5
-  run_constrained:
-    - libcurl >=8.11.1
 
 test:
   commands:

--- a/r-hdf5r-feedstock/recipe/meta.yaml
+++ b/r-hdf5r-feedstock/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - r-r6
     - r-bit64
     - hdf5 1.14.5
-    - libcurl	8.11.1
+    - libcurl 8.11.1
 
   run:
     - r-base

--- a/r-hdf5r-feedstock/recipe/meta.yaml
+++ b/r-hdf5r-feedstock/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '1.3.8' %}
+{% set version = '1.3.12' %}
 
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
@@ -11,7 +11,7 @@ source:
   url:
     - {{ cran_mirror }}/src/contrib/hdf5r_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/hdf5r/hdf5r_{{ version }}.tar.gz
-  sha256: b53281e2cf57447965849748e972de2f7fe8df0cee3538ef5813c33c7ed2302b
+  sha256: e2e736b66837f516ac3e31e7bbf41c2a0e37431757df983442ce0062dc13ff64
 
 build:
   merge_build_host: True  # [win]
@@ -44,7 +44,7 @@ requirements:
     - r-base
     - r-r6
     - r-bit64
-    - hdf5
+    - hdf5 1.14.5
 
   run:
     - r-base
@@ -59,8 +59,8 @@ test:
     - $R -e "library('hdf5r')"           # [not win]
     - "\"%R%\" -e \"library('hdf5r')\""  # [win]
 
-  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
-  # in the recipe that will be run at test time.
+  # You can also put a file called run_test.r, run_test.py, run_test.sh,
+  # or run_test.bat in the recipe that will be run at test time.
 
   # requires:
     # Put any additional test requirements here.
@@ -70,25 +70,21 @@ about:
   license: Apache License 2.0 | file LICENSE
   summary: '''HDF5'' is a data model, library and file format for storing and managing large
     amounts of data. This package provides a nearly feature complete, object oriented  wrapper
-    for the ''HDF5'' API <https://support.hdfgroup.org/HDF5/doc/RM/RM_H5Front.html>
+    for the ''HDF5'' API <https://support.hdfgroup.org/documentation/hdf5/latest/_r_m.html>
     using R6 classes. Additionally, functionality is added so that ''HDF5'' objects
     behave very similar to their corresponding R counterparts.'
   license_family: APACHE
   license_file:
     - LICENSE
 
-extra:
-  recipe-maintainers:
-    - katietz
-
 # The original CRAN metadata for this package was:
 
 # Package: hdf5r
 # Type: Package
 # Title: Interface to the 'HDF5' Binary Data Format
-# Version: 1.3.8
+# Version: 1.3.12
 # Authors@R: c( person("Holger", "Hoefling", email = "hhoeflin@gmail.com", role = c("aut", "cre")), person("Mario", "Annau", email = "mario.annau@gmail.com", role = "aut"), person("Novartis Institute for BioMedical Research (NIBR)", role = "cph") )
-# Description: 'HDF5' is a data model, library and file format for storing and managing large amounts of data. This package provides a nearly feature complete, object oriented  wrapper for the 'HDF5' API <https://support.hdfgroup.org/HDF5/doc/RM/RM_H5Front.html> using R6 classes. Additionally, functionality is added so that 'HDF5' objects behave very similar to their corresponding R counterparts.
+# Description: 'HDF5' is a data model, library and file format for storing and managing large amounts of data. This package provides a nearly feature complete, object oriented  wrapper for the 'HDF5' API <https://support.hdfgroup.org/documentation/hdf5/latest/_r_m.html> using R6 classes. Additionally, functionality is added so that 'HDF5' objects behave very similar to their corresponding R counterparts.
 # URL: https://hhoeflin.github.io/hdf5r/, https://github.com/hhoeflin/hdf5r/
 # BugReports: https://github.com/hhoeflin/hdf5r/issues
 # License: Apache License 2.0 | file LICENSE
@@ -102,11 +98,11 @@ extra:
 # NeedsCompilation: yes
 # RoxygenNote: 6.1.1.9000
 # Collate: 'Common_functions.R' 'Compound.R' 'H5constants.R' 'Helper_functions.R' 'Misc.R' 'R6Classes.R' 'R6Classes_H5A.R' 'R6Classes_H5D.R' 'R6Classes_H5File.R' 'R6Classes_H5Group.R' 'R6Classes_H5P.R' 'R6Classes_H5R.R' 'R6Classes_H5S.R' 'R6Classes_H5T.R' 'adapt_during_onLoad.R' 'convert.R' 'factor_ext.R' 'globalVariables.R' 'h5errorHandling.R' 'h5wrapper.R' 'hdf5r.R' 'high_level_UI.R' 'open_objs.R' 'zzz.R'
-# Packaged: 2023-01-21 15:37:55 UTC; hhoeflin
+# Packaged: 2025-01-19 16:02:58 UTC; hhoeflin
 # Author: Holger Hoefling [aut, cre], Mario Annau [aut], Novartis Institute for BioMedical Research (NIBR) [cph]
 # Maintainer: Holger Hoefling <hhoeflin@gmail.com>
 # Repository: CRAN
-# Date/Publication: 2023-01-21 16:10:02 UTC
+# Date/Publication: 2025-01-20 11:00:05 UTC
 
 # See
 # https://docs.conda.io/projects/conda-build for

--- a/r-hdf5r-feedstock/recipe/meta.yaml
+++ b/r-hdf5r-feedstock/recipe/meta.yaml
@@ -45,6 +45,7 @@ requirements:
     - r-r6
     - r-bit64
     - hdf5 1.14.5
+    - libcurl	8.11.1
 
   run:
     - r-base

--- a/r-hdf5r-feedstock/recipe/meta.yaml
+++ b/r-hdf5r-feedstock/recipe/meta.yaml
@@ -45,7 +45,6 @@ requirements:
     - r-r6
     - r-bit64
     - hdf5 1.14.5
-    - libcurl 8.11.1
 
   run:
     - r-base
@@ -53,6 +52,8 @@ requirements:
     - r-r6
     - r-bit64
     - hdf5
+  run_constrained:
+    - libcurl >=8.11.1
 
 test:
   commands:


### PR DESCRIPTION
**Destination channel:** r

### Links

- [PKG-6133](https://anaconda.atlassian.net/browse/PKG-6133) 
- [Upstream repository](https://cran.r-project.org/web/packages/hdf5r/index.html)

### Explanation of changes:

- Pin hdf5 to 1.14.5
- Align values of `aggregateR` `cbc.yaml` with those from the `aggregate` repo 

### Notes:

-

[PKG-6133]: https://anaconda.atlassian.net/browse/PKG-6133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ