### PR TITLE
r-ijtiff 2.3.3: Rebuild with libtiff 4.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -16,6 +16,6 @@ build_parameters:
 
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
-  - https://staging.continuum.io/prefect/fs/r-base-feedstock/pr3/6b13eff
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
+  - https://staging.continuum.io/prefect/fs/r-base-feedstock/pr3/07f6011
   - r

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,7 @@
 aggregate_check: false
 
+#upload_channels: [r]
+
 build_parameters:
   - "--R 4.3.1"
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -11,6 +11,6 @@ use_prefect_platforms:
     - linux-64
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
-  - https://staging.continuum.io/prefect/fs/r-base-feedstock/pr3/a6eda3d
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+  - https://staging.continuum.io/prefect/fs/r-base-feedstock/pr3/6b13eff
   - r

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,7 +2,8 @@ aggregate_check: false
 
 upload_channels: [r]
 
-pbp_only_deployment: prod
+use_prefect_platforms:
+    - linux-64
 
 build_parameters:
   - "--suppress-variables"
@@ -13,8 +14,6 @@ build_parameters:
   # So use '--R 4.3.1' until the issue will be fixed
   - "--R 4.3.1"
 
-use_prefect_platforms:
-    - linux-64
 
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,7 @@
 aggregate_check: false
 
-build_parameters:
-  - "--R 4.3.1"
+# build_parameters:
+#   - "--R 4.3.1"
 
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,8 @@
 aggregate_check: false
 
-#upload_channels: [r]
+upload_channels: [r]
+
+pbp_only_deployment: prod
 
 build_parameters:
   - "--R 4.3.1"

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,7 +5,10 @@ upload_channels: [r]
 pbp_only_deployment: prod
 
 build_parameters:
-  - "--R 4.3.1"
+  - "--suppress-variables"
+  - "--skip-existing"
+  - "--error-overlinking"
+  - "--variant-config-files ./aggregateR/conda_build_config.yaml 
 
 use_prefect_platforms:
     - linux-64

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,8 @@
 aggregate_check: false
 
+build_parameters:
+  - "--R 4.3.1"
+
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
   - https://staging.continuum.io/prefect/fs/r-base-feedstock/pr3/a6eda3d

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,4 @@ aggregate_check: false
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
   - https://staging.continuum.io/prefect/fs/r-base-feedstock/pr3/a6eda3d
+  - r

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,5 @@
 aggregate_check: false
+
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/r-base-feedstock/pr3/a6eda3d

--- a/abs.yaml
+++ b/abs.yaml
@@ -13,6 +13,4 @@ build_parameters:
 
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
-  - https://staging.continuum.io/prefect/fs/r-base-feedstock/pr3/07f6011
   - r

--- a/abs.yaml
+++ b/abs.yaml
@@ -12,7 +12,7 @@ build_parameters:
   - "--variant-config-files ../conda_build_config.yaml"
   # It looks like 'r_version' is ingored currently by conda-build.
   # So use '--R 4.3.1' until the issue will be fixed
-  - "--R 4.3.1"
+  # - "--R 4.3.1"
 
 
 channels:

--- a/abs.yaml
+++ b/abs.yaml
@@ -10,9 +10,6 @@ build_parameters:
   - "--skip-existing"
   - "--error-overlinking"
   - "--variant-config-files ../conda_build_config.yaml"
-  # It looks like 'r_version' is ingored currently by conda-build.
-  # So use '--R 4.3.1' until the issue will be fixed
-  # - "--R 4.3.1"
 
 
 channels:

--- a/abs.yaml
+++ b/abs.yaml
@@ -9,6 +9,9 @@ build_parameters:
   - "--skip-existing"
   - "--error-overlinking"
   - "--variant-config-files ../conda_build_config.yaml"
+  # It looks like 'r_version' is ingored currently by conda-build.
+  # So use '--R 4.3.1' until the issue will be fixed
+  - "--R 4.3.1"
 
 use_prefect_platforms:
     - linux-64

--- a/abs.yaml
+++ b/abs.yaml
@@ -8,7 +8,7 @@ build_parameters:
   - "--suppress-variables"
   - "--skip-existing"
   - "--error-overlinking"
-  - "--variant-config-files ./aggregateR/conda_build_config.yaml"
+  - "--variant-config-files ../conda_build_config.yaml"
 
 use_prefect_platforms:
     - linux-64

--- a/abs.yaml
+++ b/abs.yaml
@@ -8,7 +8,7 @@ build_parameters:
   - "--suppress-variables"
   - "--skip-existing"
   - "--error-overlinking"
-  - "--variant-config-files ./aggregateR/conda_build_config.yaml 
+  - "--variant-config-files ./aggregateR/conda_build_config.yaml"
 
 use_prefect_platforms:
     - linux-64

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,6 +3,9 @@ aggregate_check: false
 build_parameters:
   - "--R 4.3.1"
 
+use_prefect_platforms:
+    - linux-64
+
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
   - https://staging.continuum.io/prefect/fs/r-base-feedstock/pr3/a6eda3d

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,7 @@
 aggregate_check: false
 
-# build_parameters:
-#   - "--R 4.3.1"
+build_parameters:
+  - "--R 4.3.1"
 
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -59,7 +59,7 @@ ucrt64_cxx_compiler:           # [win]
 ucrt64_fortran_compiler:       # [win]
   - ucrt64-gcc-toolchain       # [win]
 
-r-base:
+r_base:
   - 4.3.1
 r_version:
   - 4.3.1

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -58,6 +58,9 @@ ucrt64_cxx_compiler:           # [win]
   - ucrt64-gcc-toolchain       # [win]
 ucrt64_fortran_compiler:       # [win]
   - ucrt64-gcc-toolchain       # [win]
+
+r-base:
+  - 4.3.1
 r_version:
   - 4.3.1
 r_implementation:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -58,7 +58,10 @@ ucrt64_cxx_compiler:           # [win]
   - ucrt64-gcc-toolchain       # [win]
 ucrt64_fortran_compiler:       # [win]
   - ucrt64-gcc-toolchain       # [win]
-
+r_version:
+  - 4.3.1
+r_implementation:
+  - 'r-base'    # [linux and x86_64]
 
 # This differs from target_platform in that it determines what subdir the compiler
 #    will target, not what subdir the compiler package will be itself.

--- a/r-ijtiff-feedstock/recipe/meta.yaml
+++ b/r-ijtiff-feedstock/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - {{ posix }}zip               # [win]
 
   host:
-    - r-base
+    - r-base {{ r_version }}
     - r-checkmate >=1.9.3
     - r-cli
     - r-dplyr

--- a/r-ijtiff-feedstock/recipe/meta.yaml
+++ b/r-ijtiff-feedstock/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   url:
     - {{ cran_mirror }}/src/contrib/ijtiff_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/ijtiff/ijtiff_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/ijtiff/ijtiff_{{ version }}.tar.gz
   sha256: bea4d66fe02970eb734bae0c8b0f3cf37d92bc2fb6f4d073b368fcc8c4236047
 
 build:

--- a/r-ijtiff-feedstock/recipe/meta.yaml
+++ b/r-ijtiff-feedstock/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - {{ posix }}zip               # [win]
 
   host:
-    - r-base {{ r_version }}
+    - r-base
     - r-checkmate >=1.9.3
     - r-cli
     - r-dplyr

--- a/r-ijtiff-feedstock/recipe/meta.yaml
+++ b/r-ijtiff-feedstock/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   url:
     - {{ cran_mirror }}/src/contrib/ijtiff_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/ijtiff/ijtiff_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/ijtiff/ijtiff_2.3.3.tar.gz
   sha256: bea4d66fe02970eb734bae0c8b0f3cf37d92bc2fb6f4d073b368fcc8c4236047
 
 build:

--- a/r-ijtiff-feedstock/recipe/meta.yaml
+++ b/r-ijtiff-feedstock/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   merge_build_host: True  # [win]
   # If this is a new build for the same version, increment the build number.
-  number: 0
+  number: 1
   # no skip
 
   # This is required to make R link correctly on Linux.
@@ -54,7 +54,7 @@ requirements:
     - r-stringr >=1.4
     - r-withr >=2.1
     - r-zeallot
-    - libtiff
+    - libtiff 4.7.0
     - jpeg
     - zlib
 

--- a/r-ijtiff-feedstock/recipe/meta.yaml
+++ b/r-ijtiff-feedstock/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
   url:
     - {{ cran_mirror }}/src/contrib/ijtiff_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/ijtiff/ijtiff_{{ version }}.tar.gz
-    - https://cran.r-project.org/src/contrib/Archive/ijtiff/ijtiff_2.3.3.tar.gz
   sha256: bea4d66fe02970eb734bae0c8b0f3cf37d92bc2fb6f4d073b368fcc8c4236047
 
 build:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7603](https://anaconda.atlassian.net/browse/PKG-7603) 
- [Upstream repository](https://cran.r-project.org/web/packages/ijtiff/index.html)

### Explanation of changes:

- Add abs.yaml:
  - Use the flag `--R 4.3.1` in `build_parameters` so that conda-build runs against this version of `r-base`
  - Use `use_prefect_platforms` to run only `linux-64` platform on Prefect. We can skip platforms in the recipe but then we can miss it if we make build-outs for other platforms.

- Add `r` to channels to pick up packages. By default, the `r` channel isn't used by Prefect
- Bump build number to 1
- Pin libtiff in host 

Add r_version and r_implementation to a generic cbc.yaml of the `aggregateR` repo

### Notes:

-

[PKG-7603]: https://anaconda.atlassian.net/browse/PKG-7603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ